### PR TITLE
v2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "clean-webpack-plugin": "^4.0.0-alpha.0",
         "copy-webpack-plugin": "^9.0.1",
         "jest": "^27.0.6",
-        "npm-auto-version": "^1.0.0",
         "prettier": "^2.3.2",
         "ts-loader": "^9.2.5",
         "typescript": "^4.6.3",
@@ -6603,30 +6602,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm-auto-version": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/npm-auto-version/-/npm-auto-version-1.0.0.tgz",
-      "integrity": "sha1-b21s8b2JEL5U71DnOMCfgSWE3jI=",
-      "dev": true,
-      "dependencies": {
-        "semver": "^5.0.3"
-      },
-      "bin": {
-        "npm-auto-version": "bin/npm-auto-version"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/npm-auto-version/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/npm-run-path": {
@@ -13240,23 +13215,6 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
-    },
-    "npm-auto-version": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/npm-auto-version/-/npm-auto-version-1.0.0.tgz",
-      "integrity": "sha1-b21s8b2JEL5U71DnOMCfgSWE3jI=",
-      "dev": true,
-      "requires": {
-        "semver": "^5.0.3"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
-      }
     },
     "npm-run-path": {
       "version": "4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jackcom/raphsducks",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jackcom/raphsducks",
-      "version": "1.2.0",
+      "version": "2.0.0",
       "license": "WTFPL",
       "dependencies": {
         "rxjs": "^7.5.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@jackcom/raphsducks",
       "version": "1.2.0",
       "license": "WTFPL",
+      "dependencies": {
+        "rxjs": "^7.5.5"
+      },
       "devDependencies": {
         "@babel/preset-env": "^7.15.0",
         "@babel/preset-typescript": "^7.15.0",
@@ -3235,14 +3238,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001274",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001274.tgz",
-      "integrity": "sha512-+Nkvv0fHyhISkiMIjnyjmf5YJcQ1IQHZN6U9TLUMroWR38FNwpsC51Gb68yueafX1V6ifOisInSgP9WJFS13ew==",
+      "version": "1.0.30001344",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001344.tgz",
+      "integrity": "sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -7198,6 +7207,14 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+      "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -7747,6 +7764,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/type-check": {
       "version": "0.3.2",
@@ -10681,9 +10703,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001274",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001274.tgz",
-      "integrity": "sha512-+Nkvv0fHyhISkiMIjnyjmf5YJcQ1IQHZN6U9TLUMroWR38FNwpsC51Gb68yueafX1V6ifOisInSgP9WJFS13ew==",
+      "version": "1.0.30001344",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001344.tgz",
+      "integrity": "sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g==",
       "dev": true
     },
     "chalk": {
@@ -13653,6 +13675,14 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "rxjs": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+      "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -14059,6 +14089,11 @@
           }
         }
       }
+    },
+    "tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
   "scripts": {
     "clean": "rm lib/bundle.js",
     "build": "npm run clean && npx webpack --mode development",
-    "test": "jest --watchAll",
-    "prepublish": "npm-auto-version && npm run build",
+    "test": "jest --watchAll --testTimeout=300000 --detectOpenHandles",
+    "preview": "npm run build && npm pack && rm -rf *.tgz",
+    "prepublish": "npm run build",
     "postpublish": "git push origin --tags"
   },
   "devDependencies": {
@@ -30,11 +31,13 @@
     "clean-webpack-plugin": "^4.0.0-alpha.0",
     "copy-webpack-plugin": "^9.0.1",
     "jest": "^27.0.6",
-    "npm-auto-version": "^1.0.0",
     "prettier": "^2.3.2",
     "ts-loader": "^9.2.5",
     "typescript": "^4.6.3",
     "webpack": "^5.51.1",
     "webpack-cli": "^4.8.0"
+  },
+  "dependencies": {
+    "rxjs": "^7.5.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackcom/raphsducks",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "A lightweight pubsub (publish-subscribe) state manager.",
   "main": "lib/bundle.js",
   "keywords": [

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,13 +5,15 @@ type ApplicationState = {
 
 /** State instance */
 type Store<T> = {
-  [x: string]: StoreUpdaterFn | any;
+
+  /** @private property: list of subscribers */
+  subscribers: ListenerFn[]
 
   /** Get [a copy of] the current application state */
-  getState(): ApplicationState;
+  getState(): T;
 
   /** Update multiple keys in state before notifying subscribers. */
-  multiple(changes: Partial<ApplicationState>): void;
+  multiple(changes: Partial<T>): void;
 
   /**
    * Reset the instance to its initialized state while preserving subscribers.
@@ -54,10 +56,10 @@ type Store<T> = {
     keys: string[],
     valueCheck?: (key: string, expectedValue: any) => boolean
   ): Unsubscriber;
-} & { [k in keyof T]: StoreUpdaterFn };
+} & { [k in keyof T]: StoreUpdaterFn<T[k]> };
 
 /** Function for updating a state key */
-type StoreUpdaterFn = { (value?: any): void };
+type StoreUpdaterFn<T> = { (value: T): void };
 
 /** State Listeners are functions that are called when the state changes */
 type ListenerFn = {


### PR DESCRIPTION
## Brings in RxJS

One sad step away from **0 dependencies**, but with good reason. [`rxjs`](https://rxjs.dev/guide/overview) has been around for a long time, and is explicitly designed for solutions like `ApplicationState`. It allows a more structured way of publishing events to multiple subscribers. 

This should NOT be a breaking change. The `createState` and immediately underlying API have not changed (type defs may be slightly improved). Please create an issue if you encounter any new bugs. 